### PR TITLE
Revert back to `&mut self` for `create_cf`/`drop_cf`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,14 +83,13 @@ use std::error;
 use std::fmt;
 use std::marker::PhantomData;
 use std::path::PathBuf;
-use std::sync::{Arc, RwLock};
 
 /// A RocksDB database.
 ///
 /// See crate level documentation for a simple usage example.
 pub struct DB {
     inner: *mut ffi::rocksdb_t,
-    cfs: Arc<RwLock<BTreeMap<String, *mut ffi::rocksdb_column_family_handle_t>>>,
+    cfs: BTreeMap<String, *mut ffi::rocksdb_column_family_handle_t>,
     path: PathBuf,
 }
 

--- a/tests/test_column_family.rs
+++ b/tests/test_column_family.rs
@@ -27,7 +27,7 @@ fn test_column_family() {
         let mut opts = Options::default();
         opts.create_if_missing(true);
         opts.set_merge_operator("test operator", test_provided_merge, None);
-        let db = DB::open(&opts, &n).unwrap();
+        let mut db = DB::open(&opts, &n).unwrap();
         let opts = Options::default();
         match db.create_cf("cf1", &opts) {
             Ok(_db) => println!("cf1 created successfully"),
@@ -80,7 +80,7 @@ fn test_column_family() {
     {}
     // should b able to drop a cf
     {
-        let db = DB::open_cf(&Options::default(), &n, &["cf1"]).unwrap();
+        let mut db = DB::open_cf(&Options::default(), &n, &["cf1"]).unwrap();
         match db.drop_cf("cf1") {
             Ok(_) => println!("cf1 successfully dropped."),
             Err(e) => panic!("failed to drop column family: {}", e),
@@ -97,7 +97,7 @@ fn test_can_open_db_with_results_of_list_cf() {
     {
         let mut opts = Options::default();
         opts.create_if_missing(true);
-        let db = DB::open(&opts, &n).unwrap();
+        let mut db = DB::open(&opts, &n).unwrap();
         let opts = Options::default();
 
         assert!(db.create_cf("cf1", &opts).is_ok());
@@ -244,7 +244,7 @@ fn test_create_duplicate_column_family() {
         opts.create_if_missing(true);
         opts.create_missing_column_families(true);
 
-        let db = match DB::open_cf(&opts, &n, &["cf1"]) {
+        let mut db = match DB::open_cf(&opts, &n, &["cf1"]) {
             Ok(d) => d,
             Err(e) => panic!("failed to create new column family: {}", e),
         };

--- a/tests/test_property.rs
+++ b/tests/test_property.rs
@@ -34,8 +34,9 @@ fn property_cf_test() {
     let n = DBPath::new("_rust_rocksdb_property_cf_test");
     {
         let opts = Options::default();
-        let db = DB::open_default(&n).unwrap();
-        let cf = db.create_cf("cf1", &opts).unwrap();
+        let mut db = DB::open_default(&n).unwrap();
+        db.create_cf("cf1", &opts).unwrap();
+        let cf = db.cf_handle("cf1").unwrap();
         let value = db.property_value_cf(cf, "rocksdb.stats").unwrap().unwrap();
 
         assert!(value.contains("Stats"));
@@ -60,8 +61,9 @@ fn property_int_cf_test() {
     let n = DBPath::new("_rust_rocksdb_property_int_cf_test");
     {
         let opts = Options::default();
-        let db = DB::open_default(&n).unwrap();
-        let cf = db.create_cf("cf1", &opts).unwrap();
+        let mut db = DB::open_default(&n).unwrap();
+        db.create_cf("cf1", &opts).unwrap();
+        let cf = db.cf_handle("cf1").unwrap();
         let total_keys = db
             .property_int_value_cf(cf, "rocksdb.estimate-num-keys")
             .unwrap();


### PR DESCRIPTION
ref. https://github.com/rust-rocksdb/rust-rocksdb/issues/279

Essentially reverts https://github.com/rust-rocksdb/rust-rocksdb/pull/197 and makes `create_cf`/`drop_cf` take `&mut self` to ensure nothing else can update the column family map.

The biggest breaking change here is that `create_cf` does not return a `ColumnFamily`. See [this comment](https://github.com/rust-rocksdb/rust-rocksdb/issues/279#issuecomment-487902919) on the original ticket for details.